### PR TITLE
Css tweaks

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,7 +15,6 @@ export default {
   font-family: 'Avenir', Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  text-align: center;
   color: #2c3e50;
 }
 </style>

--- a/src/components/TreemapConstructor.vue
+++ b/src/components/TreemapConstructor.vue
@@ -382,10 +382,6 @@ a {
 
 .columns {
   margin-top: 10px;
-  justify-content: center;
-  &:last-child {
-    margin-bottom: 0;
-  }
 }
 .column {
   h1 {

--- a/src/components/TreemapConstructor.vue
+++ b/src/components/TreemapConstructor.vue
@@ -445,7 +445,6 @@ a {
 }
 
 .buttons {
-  justify-content: center;
   display: flex;
   align-items: center;
   flex-wrap: wrap;


### PR DESCRIPTION
This is the problem on offenerhaushalt.de that is fixed with removing the `:last-child` selector:
![screen shot 2017-12-01 at 16 16 38](https://user-images.githubusercontent.com/1096357/33495520-07d56e32-d6c7-11e7-9879-5bc37a022f43.png)
